### PR TITLE
Correction to call global API class syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ var createTicketRequest = {
 	}
 };
 
-zendesk.tickets.create(createTicketRequest, function(err, req, res) {
+Zendesk().tickets.create(createTicketRequest, function(err, req, res) {
 	if (err) {
 		console.error('Zendesk error: ', err);
 		return


### PR DESCRIPTION
Unknown if this is a result of some version changes or something... I needed to to this for it to work.